### PR TITLE
Fix misnested span tag in publication entry

### DIFF
--- a/template.html
+++ b/template.html
@@ -21,7 +21,7 @@
         <h2>Publications</h2>
         <hr>
         <div class="publication-item conference-journal" id="BiDKT">
-            <span class="publication-item-authors"><span class="publication-item-myself">A, B.,</span> C, D., E, F. & G, H. </span> <span class="publication-item-year">(2021).</span></span> <span class="publication-item-title">Discovery in Something </span> <span class="publication-item-journal">Some conference. </span><span class="publication-item-publisher">Pub, pub.</span>
+            <span class="publication-item-authors"><span class="publication-item-myself">A, B.,</span> C, D., E, F. & G, H.</span> <span class="publication-item-year">(2021).</span> <span class="publication-item-title">Discovery in Something </span> <span class="publication-item-journal">Some conference. </span><span class="publication-item-publisher">Pub, pub.</span>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Remove redundant closing `</span>` in publication entry of `template.html`
- Ensure spans are properly nested and balanced

## Testing
- `python3 - <<'PY'
from html.parser import HTMLParser
class SpanChecker(HTMLParser):
    def __init__(self):
        super().__init__()
        self.stack=[]
        self.unmatched_closing=0
    def handle_starttag(self, tag, attrs):
        if tag=='span':
            self.stack.append('span')
    def handle_endtag(self, tag):
        if tag=='span':
            if not self.stack:
                self.unmatched_closing +=1
            else:
                self.stack.pop()
parser=SpanChecker()
with open('template.html') as f:
    parser.feed(f.read())
print('Unmatched closing spans:', parser.unmatched_closing)
print('Unclosed spans:', len(parser.stack))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892ae22cf848320be4b18c67bfe60af